### PR TITLE
chore: update mixpanel-browser to 2.65.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@nuxt/kit": "^3.12.4",
     "@types/mixpanel-browser": "^2.49.1",
-    "mixpanel-browser": "^2.54.0"
+    "mixpanel-browser": "^2.65.0"
   },
   "devDependencies": {
     "@nuxt/eslint-config": "^0.4.0",


### PR DESCRIPTION
A small pull request to update the mixpanel-browser to the latest version.